### PR TITLE
Solve problem to persist dependencies in bower file.

### DIFF
--- a/webapp/src/main/webapp/bower.json
+++ b/webapp/src/main/webapp/bower.json
@@ -43,5 +43,9 @@
     "angular-translate": "2.9.0",
     "autotrack": "^1.0.3",
     "angular-material": "^1.1.1"
+  },
+  "resolutions": {
+    "angular-animate": "^1.4.8",
+    "angular": "^1.4.8"
   }
 }


### PR DESCRIPTION
In order to use ngMaterial we need another version of angular-animate. Now the changes will be persisted. It does not requiere an interactive shell.

Signed-off-by: Xavier Sumba <xavier.sumba93@ucuenca.ec>