### PR TITLE
Redi 100

### DIFF
--- a/authors-module/pom.xml
+++ b/authors-module/pom.xml
@@ -194,11 +194,31 @@
             <groupId>org.apache.marmotta.ucuenca.wk.tools</groupId>
             <artifactId>commons</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion> 
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion> 
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.marmotta.ucuenca.wk.tools</groupId>
             <artifactId>vocab</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion> 
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion> 
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/authors-module/src/main/java/org/apache/marmotta/ucuenca/wk/authors/services/AuthorServiceImpl.java
+++ b/authors-module/src/main/java/org/apache/marmotta/ucuenca/wk/authors/services/AuthorServiceImpl.java
@@ -366,7 +366,19 @@ public class AuthorServiceImpl implements AuthorService {
     @Override
     public String searchDuplicates() {
         try {
-            String allAuthorsQuery = queriesService.getAuthors();
+            String allAuthorsQuery = queriesService.getAuthors(); 
+                    /*"PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX foaf: <http://xmlns.com/foaf/0.1/>  PREFIX owl: <http://www.w3.org/2002/07/owl#>  PREFIX dct: <http://purl.org/dc/terms/>  PREFIX mm: <http://marmotta.apache.org/vocabulary/sparql-functions#>  PREFIX dcat: <http://www.w3.org/ns/dcat#>  PREFIX bibo: <http://purl.org/ontology/bibo/> PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+                    + "SELECT distinct ?s WHERE {  "
+                    + "GRAPH  <http://ucuenca.edu.ec/wkhuska/authors> {     "
+                    + " ?s a foaf:Person.    ?s dct:provenance ?endpoint."
+                    + " {"
+                    + "    SELECT * { "
+                    + "        	GRAPH <http://ucuenca.edu.ec/wkhuska/endpoints> { "
+                    + "              ?endpoint uc:name \"UCUENCA\"^^xsd:string . "
+                    + "            } "
+                    + "        } "
+                    + " }"
+                    + "}}";*/
             Repository repository = new SPARQLRepository(constantService.getSPARQLEndpointURL());
             TupleQueryResult allAuthors = executeQuery(repository, allAuthorsQuery);
             
@@ -602,7 +614,7 @@ public class AuthorServiceImpl implements AuthorService {
                 if (!setResult.contains(similarAuthorResource) && !authorResource.equals(similarAuthorResource) 
                         && !setExplored.contains(similarAuthorResource)) {
                     out.println(" ");
-                    equalNames = getEqualNames(authorResource, similarAuthorResource, nombresOrig, apellidosOrig, otherGivenName, otherLastName, semanticCheck, repository);
+                    equalNames = getEqualNames(nombresOrig, apellidosOrig, otherGivenName, otherLastName, semanticCheck, repository);
                     if (equalNames && semanticCheck) {
                         
                         out.println("URI: " + authorResource + " URI2: " + similarAuthorResource);
@@ -634,7 +646,7 @@ public class AuthorServiceImpl implements AuthorService {
         return setResult;
     }
     
-    public boolean getEqualNames(String authorResource, String similarAuthorResource, String nombresOrig, String apellidosOrig, String otherGivenName, String otherLastName, boolean semanticCheck, Repository repository){
+    public boolean getEqualNames(String nombresOrig, String apellidosOrig, String otherGivenName, String otherLastName, boolean semanticCheck, Repository repository){
         boolean equal = false;
         //Getting the original names
         String givenName1 = removeAccents(nombresOrig.split(" ")[0]).toLowerCase();

--- a/authors-module/src/main/java/org/apache/marmotta/ucuenca/wk/authors/services/AuthorServiceImpl.java
+++ b/authors-module/src/main/java/org/apache/marmotta/ucuenca/wk/authors/services/AuthorServiceImpl.java
@@ -402,7 +402,7 @@ public class AuthorServiceImpl implements AuthorService {
                 
                 out.println(" Author Number: " + authorCount);
                 //bw.write(" Author Number: " + authorCount);
-                
+                log.error(" Author Number: " + authorCount, " Author Number: " + authorCount);
                 //Encontramos los nombres del autor actual
                 String getNamesQuery = queriesService.getAuthorDataQuery(authorResource);
                 TupleQueryResult namesAuthor = executeQuery(repository, getNamesQuery);

--- a/tools/commons/pom.xml
+++ b/tools/commons/pom.xml
@@ -163,6 +163,17 @@
             <artifactId>vocab</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.mapdb</groupId>
+            <artifactId>mapdb</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-arq</artifactId>
+            <version>2.13.0</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
    
 </project>

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/function/Cache.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/function/Cache.java
@@ -1,0 +1,138 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.apache.marmotta.ucuenca.wk.commons.function;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+//import java.util.ArrayList;
+//import java.util.List;
+import java.util.concurrent.TimeUnit;
+//import java.util.logging.Level;
+//import java.util.logging.Logger;
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonObject;
+import org.mapdb.BTreeMap;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.HTreeMap;
+import org.mapdb.Serializer;
+import org.mapdb.serializer.SerializerCompressionWrapper;
+import org.mapdb.serializer.SerializerArrayTuple;
+
+/**
+ *
+ * @author Jose Luis Cullcay
+ */
+public final class Cache {
+
+    private DB db = null;
+    private DB dbDist = null;
+    private HTreeMap<String, String> create = null;
+    private BTreeMap<Object[], Double> distance = null;
+    private double limit = 0.001;
+    //private List<String> BlackList = new ArrayList();
+    //private JsonObject config = null;
+    
+    //private static final Cache INSTANCE = new Cache();
+
+    private Cache() {
+        InputStream resourceAsStream = this.getClass().getResourceAsStream("/config.cnf");
+        String theString = null;
+        try {
+            theString = IOUtils.toString(resourceAsStream, Charset.defaultCharset().toString());
+        } catch (IOException ex) {
+            //Logger.getLogger(Cache.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        JsonObject config = JSON.parse(theString).getAsObject();
+        
+        
+        db = DBMaker.fileDB(config.get("CacheFile").getAsString().value()).fileLockDisable().make();
+        
+        dbDist = DBMaker.fileDB(config.get("DistanceFile").getAsString().value()).fileLockDisable().make();
+        
+        create = db.hashMap("cache", Serializer.STRING, new SerializerCompressionWrapper(Serializer.STRING)).expireAfterCreate(365, TimeUnit.DAYS).createOrOpen();
+
+        distance = dbDist.treeMap("distance")
+                .keySerializer(new SerializerArrayTuple(Serializer.STRING, Serializer.STRING))
+                .valueSerializer(Serializer.DOUBLE)
+                .createOrOpen();
+        
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            public void run() {
+                try {
+                    //System.out.println("Killing ");
+                    kill();
+                } catch (SQLException ex) {
+                    //Logger.getLogger(Cache.class.getName()).log(Level.SEVERE, null, ex);
+                }
+            }
+        }
+        ));
+    }
+
+    public void put(String key, String value) {
+        create.put(key, value);
+        if (Math.random() < limit) {
+            db.commit();
+        }
+    }
+
+    public void kill() throws SQLException {
+        if (db != null) {
+            db.close();
+        }
+        if (dbDist != null) {
+            dbDist.close();
+        }
+        create.close();
+        distance.close();
+    }
+
+    public String get(String key) {
+        return create.get(key);
+    }
+
+    public Double getDistance(String word1, String word2) {
+        
+        Double dist = distance.get(new Object[]{word1, word2});
+        
+        return (dist != null) ? dist : distance.get(new Object[]{word2, word1});
+    }
+    
+    public void putDistance(String word1, String word2, Double dist) {
+        distance.put(new Object[]{word1, word2}, dist);
+        if (Math.random() < limit) {
+            dbDist.commit();
+        }
+    }  
+
+    public static Cache getInstance() {
+        return new Cache();
+    }
+
+    public String getMD5(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] messageDigest = md.digest(input.getBytes());
+            BigInteger number = new BigInteger(1, messageDigest);
+            String hashtext = number.toString(16);
+            // Now we need to zero pad it if you actually want the full 32 chars.
+            while (hashtext.length() < 32) {
+                hashtext = "0" + hashtext;
+            }
+            return hashtext;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/function/SemanticDistance.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/function/SemanticDistance.java
@@ -13,11 +13,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
+//import java.sql.Connection;
+//import java.sql.DriverManager;
+//import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Statement;
+//import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -30,8 +30,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 
-import org.apache.marmotta.ucuenca.wk.commons.impl.CommonsServicesImpl;
-import org.apache.marmotta.ucuenca.wk.commons.service.CommonsServices;
+//import org.apache.marmotta.ucuenca.wk.commons.impl.CommonsServicesImpl;
+//import org.apache.marmotta.ucuenca.wk.commons.service.CommonsServices;
 
 /**
  *
@@ -41,12 +41,13 @@ public class SemanticDistance {
 
     // JDBC driver name and database URL
     private String dburl = "";
+    private final TranslateForSemanticDistance trans = new TranslateForSemanticDistance();
     //  Database credentials
-    private String user = "";
-    private String pass = "";
-    private CommonsServices commonservices = new CommonsServicesImpl();
+    //private String user = "";
+    //private String pass = "";
+    //private CommonsServices commonservices = new CommonsServicesImpl();
 
-    private Connection conn = null;
+    //private Connection conn = null;
     //Statement stmt = null;
 
     public SemanticDistance() throws IOException, ClassNotFoundException {
@@ -57,8 +58,8 @@ public class SemanticDistance {
         String theString = IOUtils.toString(resourceAsStream, Charset.defaultCharset().toString());
         config = parser.parse(theString).getAsJsonObject();
         dburl = dburl + config.get("dbServer").getAsString() + "/" + config.get("dbSchema").getAsString();
-        user = config.get("dbUser").getAsString();
-        pass = config.get("dbPassword").getAsString();
+        //user = config.get("dbUser").getAsString();
+        //pass = config.get("dbPassword").getAsString();
 
     }
 
@@ -70,8 +71,8 @@ public class SemanticDistance {
      * @param args the command line arguments
      */
     public synchronized double semanticKeywordsDistance(List<String> a, List<String> b) throws ClassNotFoundException, SQLException, IOException {
-        Class.forName("org.postgresql.Driver");
-        conn = DriverManager.getConnection(dburl, user, pass);
+        //Class.forName("org.postgresql.Driver");
+        //conn = DriverManager.getConnection(dburl, user, pass);
         ConcurrentHashMap<String, List<String>> map = new ConcurrentHashMap<>();
         List<String> authors = new ArrayList();
         authors.add("a1");
@@ -120,7 +121,7 @@ public class SemanticDistance {
             }
         }
 
-        conn.close();
+        //conn.close();
         return mapEntry(result);
     }
     
@@ -128,8 +129,8 @@ public class SemanticDistance {
      * @param args the command line arguments
      */
     public synchronized double nwdDistance(List<String> a, List<String> b) throws ClassNotFoundException, SQLException, IOException {
-        Class.forName("org.postgresql.Driver");
-        conn = DriverManager.getConnection(dburl, user, pass);
+        //Class.forName("org.postgresql.Driver");
+        //conn = DriverManager.getConnection(dburl, user, pass);
         ConcurrentHashMap<String, List<String>> map = new ConcurrentHashMap<>();
         List<String> authors = new ArrayList();
         authors.add("a1");
@@ -185,7 +186,7 @@ public class SemanticDistance {
             }
         }
 
-        conn.close();
+        //conn.close();
         return mapEntry(result);
     }
 
@@ -217,7 +218,7 @@ public class SemanticDistance {
     }
 
     private List<String> formatList(List<String> a) throws SQLException, IOException, ClassNotFoundException {
-        TranslateForSemanticDistance trans = new TranslateForSemanticDistance();
+        //TranslateForSemanticDistance trans = new TranslateForSemanticDistance();
         a = trans.traductor(a);//new LinkedList<String>(java.util.Arrays.asList(t1_.split("\\s\\|\\s")));
         a = trans.clean(a);
             a = topT(a, (int) (2.0 * Math.log(a.size())));
@@ -225,7 +226,7 @@ public class SemanticDistance {
     }
     
     private List<String> formatList(List<String> a, Integer top) throws SQLException, IOException, ClassNotFoundException {
-        TranslateForSemanticDistance trans = new TranslateForSemanticDistance();
+        //TranslateForSemanticDistance trans = new TranslateForSemanticDistance();
         a = trans.traductor(a);//new LinkedList<String>(java.util.Arrays.asList(t1_.split("\\s\\|\\s")));
         a = trans.clean(a);
         if (top == 0) {
@@ -274,39 +275,79 @@ public class SemanticDistance {
     }
 
     private double ngd(String a, String b) throws IOException, SQLException {
-        int min = 0;
-        int min2 = 1;
-        a = a.trim();
-        b = b.trim();
-
-        if (a.compareToIgnoreCase(b) == min) {
-            return 0;
+        /*
+        Statement stmt = conn.createStatement();
+        String sql;
+        sql = "SELECT * FROM distance where ((distance.\"firstWord\"='" + a + "' and distance.\"secondWord\"='" + b + "') or (distance.\"firstWord\"='" + b + "' and distance.\"secondWord\"='" + a + "'))";
+        //log.info("Estado de la coneccion a la Base de datos http2: Cerrada:" + conn.isClosed() + " URL: " + dburl + "User: " + user + ". Pass: " + pass );
+        java.sql.ResultSet rs;
+                
+        try {
+            rs = stmt.executeQuery(sql);
+            return rs.getDouble("coefficient");
+        } catch (Exception ex) {
+            rs = null;
+            //log.error("Error while executing the sql in http2: " + sql + ". Message Translator: " + ex.getMessage() );
         }
+        */
+        
+        Cache cache = Cache.getInstance();
+        
+        Double dist = cache.getDistance(a, b);
+        
+        if (dist == null) {
+            int min = 0;
+            int min2 = 1;
+            a = a.trim();
+            b = b.trim();
 
-        //double n0 = getResultsCount(""+a+"");
-        //double n1 = getResultsCount(""+b+"");
-        //String c = ""+a+" "+b+"";
-        double n0 = getResultsCount("\"" + a + "\"~10");
-        double n1 = getResultsCount("\"" + b + "\"~10");
-        String c = "\"" + a + " " + b + "\"~50";
+            if (a.compareToIgnoreCase(b) == min) {
+                return 0;
+            }
 
-        double n2 = getResultsCount(c);
-        double m = 5029469;
-        double distance = 0;
-        int measure = 0;
-        double l1 = Math.max(Math.log10(n0), Math.log10(n1)) - Math.log10(n2);
-        double l2 = Math.log10(m) - Math.min(Math.log10(n0), Math.log10(n1));
+            //double n0 = getResultsCount(""+a+"");
+            //double n1 = getResultsCount(""+b+"");
+            //String c = ""+a+" "+b+"";
+            double n0 = getResultsCount("\"" + a + "\"~10");
+            double n1 = getResultsCount("\"" + b + "\"~10");
+            String c = "\"" + a + " " + b + "\"~50";
 
-        if (measure == min) {
-            distance = l1 / l2;
+            double n2 = getResultsCount(c);
+            double m = 5029469;
+            double distance = 0;
+            int measure = 0;
+            double l1 = Math.max(Math.log10(n0), Math.log10(n1)) - Math.log10(n2);
+            double l2 = Math.log10(m) - Math.min(Math.log10(n0), Math.log10(n1));
+
+            if (measure == min) {
+                distance = l1 / l2;
+            }
+            if (measure == min2) {
+                distance = 1 - (Math.log10(n2) / Math.log10(n0 + n1 - n2));
+            }
+            if (n0 == min || n1 == min || n2 == min) {
+                distance = 1;
+            }
+            
+            cache.putDistance(a, b, distance);
+            cache.kill();
+            return distance;
+        } else {
+            cache.kill();
+            return dist;
         }
-        if (measure == min2) {
-            distance = 1 - (Math.log10(n2) / Math.log10(n0 + n1 - n2));
+        /*
+        try {
+            PreparedStatement stmt2 = conn.prepareStatement("INSERT INTO distance (firstWord, secondWord, coefficient) values (?, ?, ?)");
+            stmt2.setString(1, a);
+            stmt2.setString(2, b);
+            stmt2.setDouble(3, distance);
+            stmt2.executeUpdate();
+            stmt2.close();
+        } catch (Exception e) {
+            //log.error("Error in the http2 Insert Function. Used by TraductorYandex. Possibly the database." + e.getMessage());
         }
-        if (n0 == min || n1 == min || n2 == min) {
-            distance = 1;
-        }
-        return distance;
+        */
     }
 
     private double getResultsCount(String query) throws IOException, SQLException {
@@ -356,18 +397,18 @@ public class SemanticDistance {
 
     private synchronized String http(String s) throws SQLException, IOException {
 
-        Statement stmt = conn.createStatement();
-        String sql;
-        sql = "SELECT * FROM cache where cache.key='" + commonservices.getMD5(s) + "'";
-        java.sql.ResultSet rs = stmt.executeQuery(sql);
+        //Statement stmt = conn.createStatement();
+        //String sql;
+        //sql = "SELECT * FROM cache where cache.key='" + commonservices.getMD5(s) + "'";
+        //java.sql.ResultSet rs = stmt.executeQuery(sql);
         String resp = "";
-        if (rs.next()) {
+        /*if (rs.next()) {
             resp = rs.getString("value");
             rs.close();
             stmt.close();
         } else {
             rs.close();
-            stmt.close();
+            stmt.close();*/
             final URL url = new URL(s);
             final URLConnection connection = url.openConnection();
             connection.setConnectTimeout(60000);
@@ -381,7 +422,7 @@ public class SemanticDistance {
             }
             reader.close();
 
-            try {
+            /*try {
                 JsonParser parser = new JsonParser();
                 parser.parse(resp);
                 PreparedStatement stmt2 = conn.prepareStatement("INSERT INTO cache (key, value) values (?, ?)");
@@ -392,7 +433,7 @@ public class SemanticDistance {
             } catch (Exception e) {
 
             }
-        }
+        }*/
 
         return resp;
     }

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/function/TranslateForSemanticDistance.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/function/TranslateForSemanticDistance.java
@@ -212,7 +212,7 @@ public class TranslateForSemanticDistance {
                 e.printStackTrace(new PrintStream(System.out));
 
                 try {
-                    Thread.sleep(1000);
+                    Thread.sleep(400);
                 } catch (InterruptedException ex) {
                     Logger.getLogger(SemanticDistance.class.getName()).log(Level.SEVERE, null, ex);
                 }

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/DistanceServiceImpl.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/DistanceServiceImpl.java
@@ -22,6 +22,7 @@ import org.simmetrics.simplifiers.Simplifiers;
 import org.simmetrics.tokenizers.Tokenizers;
 import org.simmetrics.StringMetric;
 import static org.simmetrics.StringMetricBuilder.with;
+import org.simmetrics.metrics.JaccardSimilarity;
 
 /**
  *
@@ -33,11 +34,22 @@ public class DistanceServiceImpl implements DistanceService {
     private org.slf4j.Logger log;
 
     private CommonsServices commonService = new CommonsServicesImpl();
+    private SemanticDistance dist = null;
+
+    public DistanceServiceImpl() {
+        try {
+            this.dist = new SemanticDistance();
+        } catch (IOException ex) {
+            Logger.getLogger(DistanceServiceImpl.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (ClassNotFoundException ex) {
+            Logger.getLogger(DistanceServiceImpl.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
 
     @Override
     public boolean semanticComparison(List<String> listA, List<String> listB) {
         try {
-            SemanticDistance dist = new SemanticDistance();
+            //SemanticDistance dist = new SemanticDistance();
             double value = dist.semanticKeywordsDistance(listA, listB);
 
             double semthreshold = Double.parseDouble(commonService.readPropertyFromFile("parameters.properties", "semanticDistanceListAListB"));
@@ -54,7 +66,7 @@ public class DistanceServiceImpl implements DistanceService {
     @Override
     public Double semanticComparisonValue(List<String> listA, List<String> listB) {
         try {
-            SemanticDistance dist = new SemanticDistance();
+            //SemanticDistance dist = new SemanticDistance();
             return dist.nwdDistance(listA, listB); //double value = dist.semanticKeywordsDistance(listA, listB);
 
         } catch (IOException | ClassNotFoundException | SQLException ex) {
@@ -125,6 +137,17 @@ public class DistanceServiceImpl implements DistanceService {
         float similarity = (float) ((compare + compare2) / 2.0);
 
         return similarity;
+    }
+    
+    @Override
+    public float jaccardDistance(String param1, String param2) {
+        StringMetric metric2
+                = with(new JaccardSimilarity<String>())
+                .simplify(Simplifiers.removeDiacritics())
+                .simplify(Simplifiers.toLowerCase())
+                .tokenize(Tokenizers.qGram(2)).tokenizerCache().build();
+
+        return metric2.compare(param1, param2);
     }
 
 }

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/GetAuthorsGraphDataImpl.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/GetAuthorsGraphDataImpl.java
@@ -39,7 +39,8 @@ public class GetAuthorsGraphDataImpl implements GetAuthorsGraphData {
 
     private CommonsServices commonService = new CommonsServicesImpl();
 
-    private ConstantService constantService = new ConstantServiceImpl();
+    @Inject
+    private ConstantService constantService;
 
     private DistanceService distanceService = new DistanceServiceImpl();
 

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/QueriesServiceImpl.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/QueriesServiceImpl.java
@@ -234,6 +234,7 @@ public class QueriesServiceImpl implements QueriesService {
                 + "SELECT ?o WHERE {"
                 + "  GRAPH <" + con.getAuthorsGraph() + "> { "
                 + "     <" + authorResource + "> owl:sameAs  ?o . "
+                + "     <" + authorResource + "> a foaf:Person . "
                 + "   }"
                 + "}";
     }
@@ -376,6 +377,12 @@ public class QueriesServiceImpl implements QueriesService {
 
     @Override
     public String getAuthorsByName(String graph, String firstName, String lastName) {
+        int one = 1;
+        String option = ", 'i'";
+        if (firstName.length() == one) {
+            option = "";
+        }
+        
         return PREFIXES
                 + "SELECT distinct ?subject ?name (STR(?fName)  AS ?firstName) (STR(?lName)  AS ?lastName)  WHERE { "
                 + getGraphString(graph) + "{ "
@@ -383,7 +390,7 @@ public class QueriesServiceImpl implements QueriesService {
                 + " foaf:name ?name; "
                 + " foaf:firstName ?fName; "
                 + " foaf:lastName ?lName. "
-                + "    filter(regex(?fName, '" + firstName + "', 'i')). " //"^M$"
+                + "    filter(regex(?fName, '" + firstName + "'" + option + ")). " //"^M$"
                 + "    filter(regex(?lName, '" + lastName + "', 'i')). " //"^Espinoza"
                 + "  } "
                 + "}";
@@ -501,7 +508,7 @@ public class QueriesServiceImpl implements QueriesService {
     @Override
     public String getAuthorsKeywordsQuery(String resource) {
         return PREFIXES + " SELECT DISTINCT ?keyword FROM <" + con.getAuthorsGraph() + "> "
-                + " WHERE { <" + resource + "> dct:subject ?keyword. } limit 50";
+                + " WHERE { <" + resource + "> dct:subject ?keyword. filter(strlen(?keyword) < 41) } limit 50";
     }
     
     @Override

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/QueriesServiceImpl.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/impl/QueriesServiceImpl.java
@@ -223,9 +223,9 @@ public class QueriesServiceImpl implements QueriesService {
         return PREFIXES
                 + "SELECT ?s WHERE {"
                 + "  GRAPH  <" + con.getAuthorsGraph() + "> { "
-                + "    ?s a foaf:Person. "
+                + "    ?s a foaf:Person. ?s foaf:name ?name. " 
                 + "   }"
-                + "}";
+                + "} order by desc(strlen(str(?name)))";
     }
 
     @Override
@@ -337,7 +337,8 @@ public class QueriesServiceImpl implements QueriesService {
                 //</editor-fold>
                 + " { select ?status "
                 + "     where { " + getGraphString(endpointsgraph) + " {"
-                + "     ?provenance <http://ucuenca.edu.ec/ontology#status> ?status "
+                + "     ?provenance <http://ucuenca.edu.ec/ontology#status> ?status. "
+                //+ "     ?provenance <http://ucuenca.edu.ec/ontology#name> \"UCUENCA\"^^xsd:string ."
                 + " }}} filter (regex(?status,\"true\")) "
                 // + "filter (mm:fulltext-search(?name,\"Víctor Saquicela\")) "
                 + "                }} ";

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/service/ConstantService.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/service/ConstantService.java
@@ -28,7 +28,8 @@ public interface ConstantService {
             + " PREFIX mm: <http://marmotta.apache.org/vocabulary/sparql-functions#> "
             + " PREFIX uc: <http://ucuenca.edu.ec/ontology#> "
             + " PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> "
-            + " PREFIX bibo: <http://purl.org/ontology/bibo/> ";
+            + " PREFIX bibo: <http://purl.org/ontology/bibo/> "
+            + " PREFIX dc: <http://purl.org/dc/elements/1.1/> ";
 
     String getBaseURI();
 

--- a/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/service/DistanceService.java
+++ b/tools/commons/src/main/java/org/apache/marmotta/ucuenca/wk/commons/service/DistanceService.java
@@ -30,4 +30,7 @@ public interface DistanceService {
     Double semanticComparisonValue(List<String> listA, List<String> listB);
 
     double cosineSimilarityAndLevenshteinDistance(String param1, String param2);
+    
+    float jaccardDistance(String param1, String param2);
+    
 }

--- a/tools/commons/src/main/resources/config.cnf
+++ b/tools/commons/src/main/resources/config.cnf
@@ -3,6 +3,8 @@
 	"dbSchema":"cache",
 	"dbUser":"marmotta",
 	"dbPassword":"marmotta",
+        "CacheFile": "data.db",
+        "DistanceFile": "distance.db",
 	"contextQuery":"select distinct ?d where { {<|?|> <http://rdaregistry.info/Elements/a/P50195> ?b } union { <|?|> <http://rdaregistry.info/Elements/a/P50161> ?b } union { ?b <http://purl.org/dc/terms/contributor> <|?|>} union { ?b <http://purl.org/dc/terms/creator> <|?|>} . { ?b <http://schema.org/mentions> ?c . ?c <http://purl.org/saws/ontology#refersTo> ?d . } UNION { ?b <http://purl.org/dc/terms/subject> ?d } UNION { ?b <http://vivoweb.org/ontology/core#freetextKeyword> ?d } . filter (isLiteral (?d)) }",
 	"stopwords":["development","using","method","implementation","promas","wine","white","university","ecuador","republic of ecuador","resources","expertise","-5","inform","quito","ecuadorian","fen? am main","inform crime? tico","ecuatorianidad","fen? am main","cuenca (ecuador)","sigsig","cuenca-ecuador","san bartolomé","cuenca, ecuador"]
 }


### PR DESCRIPTION

Updates in the Common's Module

- Update distance: Correction of an error in Get Author Graph functions. Using injection.

Changes in queries: 

1. If we send only one letter to query as the name of the author, take into consideration if it is uppercase or lowercase.

2. Length of the subjects: now the function getSubjects do not search for subjects that are too big. They could break something in the future.

3. The function getSameAsAuthors retrieves only authors that are of the type foaf:Person in the Author's graphs 

 Update in the algorithm for finding the distance between words:

1. Implementation of a database in MapDB 

2. Use of the database in MapDB as a cache for translated words and also for the semantic comparison.

3. Elimination of the use of the cache DB used in postgres.

4. Prioritize the use of the Bing translator over the Yandex one.


Update in the Dspace Provider

1. Now this provider saves the author, all the important information about the publication, the subject and the year.

Update in the Author's Module

Disambiguation of authors. Corrected to the search for duplicates. Implemented a better sintactic and semantic comparison.

The sintactic comparison uses Jaccard distance.